### PR TITLE
Add setChangelogCollectionName and setLockCollectionName in MongoBee

### DIFF
--- a/src/main/java/com/github/mongobee/Mongobee.java
+++ b/src/main/java/com/github/mongobee/Mongobee.java
@@ -47,6 +47,9 @@ public class Mongobee implements InitializingBean {
 
   private MongoTemplate mongoTemplate;
   private Jongo jongo;
+  
+  private static final String DEFAULT_CHANGELOG_COLLECTION_NAME = "dbchangelog";
+  private static final String DEFAULT_LOCK_COLLECTION_NAME = "mongobeelock";
 
   /**
    * <p>Simple constructor with default configuration of host (localhost) and port (27017). Although
@@ -68,7 +71,7 @@ public class Mongobee implements InitializingBean {
   public Mongobee(MongoClientURI mongoClientURI) {
     this.mongoClientURI = mongoClientURI;
     this.setDbName(mongoClientURI.getDatabase());
-    this.dao = new ChangeEntryDao();
+    this.dao = new ChangeEntryDao(DEFAULT_CHANGELOG_COLLECTION_NAME, DEFAULT_LOCK_COLLECTION_NAME);
   }
 
   /**
@@ -81,7 +84,7 @@ public class Mongobee implements InitializingBean {
    */
   public Mongobee(MongoClient mongoClient) {
     this.mongoClient = mongoClient;
-    this.dao = new ChangeEntryDao();
+    this.dao = new ChangeEntryDao(DEFAULT_CHANGELOG_COLLECTION_NAME, DEFAULT_LOCK_COLLECTION_NAME);
   }
 
   /**
@@ -333,6 +336,16 @@ public class Mongobee implements InitializingBean {
   public Mongobee setJongo(Jongo jongo) {
     this.jongo = jongo;
     return this;
+  }
+  
+  public Mongobee setChangelogCollectionName(String changelogCollectionName) {
+	this.dao.setChangelogCollectionName(changelogCollectionName);
+	return this;
+  }
+  
+  public Mongobee setLockCollectionName(String lockCollectionName) {
+	this.dao.setLockCollectionName(lockCollectionName);
+	return this;
   }
 
   /**

--- a/src/main/java/com/github/mongobee/changeset/ChangeEntry.java
+++ b/src/main/java/com/github/mongobee/changeset/ChangeEntry.java
@@ -12,8 +12,6 @@ import org.bson.Document;
  * @since 27/07/2014
  */
 public class ChangeEntry {
-  public static final String CHANGELOG_COLLECTION = "dbchangelog"; // ! Don't change due to backward compatibility issue
-
   public static final String KEY_CHANGEID = "changeId";
   public static final String KEY_AUTHOR = "author";
   public static final String KEY_TIMESTAMP = "timestamp";
@@ -25,7 +23,7 @@ public class ChangeEntry {
   private Date timestamp;
   private String changeLogClass;
   private String changeSetMethodName;
-
+  
   public ChangeEntry(String changeId, String author, Date timestamp, String changeLogClass, String changeSetMethodName) {
     this.changeId = changeId;
     this.author = author;
@@ -79,4 +77,5 @@ public class ChangeEntry {
   public String getChangeSetMethodName() {
     return this.changeSetMethodName;
   }
+  
 }

--- a/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
+++ b/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
@@ -1,11 +1,8 @@
 package com.github.mongobee.dao;
 
-import static com.github.mongobee.changeset.ChangeEntry.CHANGELOG_COLLECTION;
-
 import org.bson.Document;
 
 import com.github.mongobee.changeset.ChangeEntry;
-import com.mongodb.DBCollection;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
@@ -15,6 +12,12 @@ import com.mongodb.client.model.IndexOptions;
  * @since 10.12.14
  */
 public class ChangeEntryIndexDao {
+
+  private String changelogCollectionName;
+	  
+  public ChangeEntryIndexDao(String changelogCollectionName) {
+	this.changelogCollectionName = changelogCollectionName;
+  }
 
   public void createRequiredUniqueIndex(MongoCollection<Document> collection) {
     collection.createIndex(new Document()
@@ -27,7 +30,7 @@ public class ChangeEntryIndexDao {
   public Document findRequiredChangeAndAuthorIndex(MongoDatabase db) {
     MongoCollection<Document> indexes = db.getCollection("system.indexes");
     Document index = indexes.find(new Document()
-        .append("ns", db.getName() + "." + CHANGELOG_COLLECTION)
+        .append("ns", db.getName() + "." + changelogCollectionName)
         .append("key", new Document().append(ChangeEntry.KEY_CHANGEID, 1).append(ChangeEntry.KEY_AUTHOR, 1))
     ).first();
 
@@ -45,6 +48,10 @@ public class ChangeEntryIndexDao {
 
   public void dropIndex(MongoCollection<Document> collection, Document index) {
     collection.dropIndex(index.get("name").toString());
+  }
+
+  public void setChangelogCollectionName(String changelogCollectionName) {
+	this.changelogCollectionName = changelogCollectionName;
   }
 
 }

--- a/src/test/java/com/github/mongobee/dao/ChangeEntryDaoTest.java
+++ b/src/test/java/com/github/mongobee/dao/ChangeEntryDaoTest.java
@@ -1,6 +1,5 @@
 package com.github.mongobee.dao;
 
-import static com.github.mongobee.changeset.ChangeEntry.CHANGELOG_COLLECTION;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -11,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import org.bson.Document;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.github.fakemongo.Fongo;
 import com.github.mongobee.exception.MongobeeConfigurationException;
@@ -26,12 +24,14 @@ import com.mongodb.client.MongoDatabase;
 public class ChangeEntryDaoTest {
   private static final String TEST_SERVER = "testServer";
   private static final String DB_NAME = "mongobeetest";
+  private static final String CHANGELOG_COLLECTION_NAME = "dbchangelog";
+  private static final String LOCK_COLLECTION_NAME = "mongobeelock";
 
   @Test
   public void shouldCreateChangeIdAuthorIndexIfNotFound() throws MongobeeConfigurationException {
 
     // given
-    ChangeEntryDao dao = new ChangeEntryDao();
+    ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME);
 
     MongoClient mongoClient = mock(MongoClient.class);
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
@@ -59,7 +59,7 @@ public class ChangeEntryDaoTest {
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
     when(mongoClient.getDatabase(anyString())).thenReturn(db);
 
-    ChangeEntryDao dao = new ChangeEntryDao();
+    ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME);
     ChangeEntryIndexDao indexDaoMock = mock(ChangeEntryIndexDao.class);
     when(indexDaoMock.findRequiredChangeAndAuthorIndex(db)).thenReturn(new Document());
     when(indexDaoMock.isUnique(any(Document.class))).thenReturn(true);
@@ -69,9 +69,9 @@ public class ChangeEntryDaoTest {
     dao.connectMongoDb(mongoClient, DB_NAME);
 
     //then
-    verify(indexDaoMock, times(0)).createRequiredUniqueIndex(db.getCollection(CHANGELOG_COLLECTION));
+    verify(indexDaoMock, times(0)).createRequiredUniqueIndex(db.getCollection(CHANGELOG_COLLECTION_NAME));
     // and not
-    verify(indexDaoMock, times(0)).dropIndex(db.getCollection(CHANGELOG_COLLECTION), new Document());
+    verify(indexDaoMock, times(0)).dropIndex(db.getCollection(CHANGELOG_COLLECTION_NAME), new Document());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class ChangeEntryDaoTest {
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
     when(mongoClient.getDatabase(anyString())).thenReturn(db);
 
-    ChangeEntryDao dao = new ChangeEntryDao();
+    ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME);
     ChangeEntryIndexDao indexDaoMock = mock(ChangeEntryIndexDao.class);
     when(indexDaoMock.findRequiredChangeAndAuthorIndex(db)).thenReturn(new Document());
     when(indexDaoMock.isUnique(any(Document.class))).thenReturn(false);
@@ -105,7 +105,7 @@ public class ChangeEntryDaoTest {
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
     when(mongoClient.getDatabase(anyString())).thenReturn(db);
 
-    ChangeEntryDao dao = new ChangeEntryDao();
+    ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME);
     ChangeEntryIndexDao indexDaoMock = mock(ChangeEntryIndexDao.class);
     dao.setIndexDao(indexDaoMock);
 
@@ -128,7 +128,7 @@ public class ChangeEntryDaoTest {
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
     when(mongoClient.getDatabase(anyString())).thenReturn(db);
 
-    ChangeEntryDao dao = new ChangeEntryDao();
+    ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME);
 
     LockDao lockDao = mock(LockDao.class);
     when(lockDao.acquireLock(any(MongoDatabase.class))).thenReturn(true);
@@ -151,7 +151,7 @@ public class ChangeEntryDaoTest {
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
     when(mongoClient.getDatabase(anyString())).thenReturn(db);
 
-    ChangeEntryDao dao = new ChangeEntryDao();
+    ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME);
 
     LockDao lockDao = mock(LockDao.class);
     dao.setLockDao(lockDao);
@@ -173,7 +173,7 @@ public class ChangeEntryDaoTest {
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
     when(mongoClient.getDatabase(anyString())).thenReturn(db);
 
-    ChangeEntryDao dao = new ChangeEntryDao();
+    ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME);
 
     LockDao lockDao = mock(LockDao.class);
     dao.setLockDao(lockDao);

--- a/src/test/java/com/github/mongobee/dao/ChangeEntryIndexDaoTest.java
+++ b/src/test/java/com/github/mongobee/dao/ChangeEntryIndexDaoTest.java
@@ -1,6 +1,5 @@
 package com.github.mongobee.dao;
 
-import static com.github.mongobee.changeset.ChangeEntry.CHANGELOG_COLLECTION;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -28,8 +27,9 @@ public class ChangeEntryIndexDaoTest {
   private static final String TEST_SERVER = "testServer";
   private static final String DB_NAME = "mongobeetest";
   private static final String CHANGEID_AUTHOR_INDEX_NAME = "changeId_1_author_1";
+  private static final String CHANGELOG_COLLECTION_NAME = "dbchangelog";
 
-  private ChangeEntryIndexDao dao = new ChangeEntryIndexDao();
+  private ChangeEntryIndexDao dao = new ChangeEntryIndexDao(CHANGELOG_COLLECTION_NAME);
 
   @Test
   public void shouldCreateRequiredUniqueIndex() {
@@ -39,7 +39,7 @@ public class ChangeEntryIndexDaoTest {
     when(mongo.getDatabase(Mockito.anyString())).thenReturn(db);
 
     // when
-    dao.createRequiredUniqueIndex(db.getCollection(CHANGELOG_COLLECTION));
+    dao.createRequiredUniqueIndex(db.getCollection(CHANGELOG_COLLECTION_NAME));
 
     // then
     Document createdIndex = findIndex(db, CHANGEID_AUTHOR_INDEX_NAME);
@@ -55,7 +55,7 @@ public class ChangeEntryIndexDaoTest {
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
     when(mongo.getDatabase(Mockito.anyString())).thenReturn(db);
 
-    MongoCollection<Document> collection = db.getCollection(CHANGELOG_COLLECTION);
+    MongoCollection<Document> collection = db.getCollection(CHANGELOG_COLLECTION_NAME);
     collection.createIndex(new Document()
         .append(ChangeEntry.KEY_CHANGEID, 1)
         .append(ChangeEntry.KEY_AUTHOR, 1));
@@ -67,7 +67,7 @@ public class ChangeEntryIndexDaoTest {
     assertFalse(dao.isUnique(createdIndex));
 
     // when
-    dao.dropIndex(db.getCollection(CHANGELOG_COLLECTION), index);
+    dao.dropIndex(db.getCollection(CHANGELOG_COLLECTION_NAME), index);
 
     // then
     assertNull(findIndex(db, CHANGEID_AUTHOR_INDEX_NAME));
@@ -75,7 +75,7 @@ public class ChangeEntryIndexDaoTest {
 
   private Document findIndex(MongoDatabase db, String indexName) {
 
-    for (MongoCursor<Document> iterator = db.getCollection(CHANGELOG_COLLECTION).listIndexes().iterator(); iterator.hasNext(); ) {
+    for (MongoCursor<Document> iterator = db.getCollection(CHANGELOG_COLLECTION_NAME).listIndexes().iterator(); iterator.hasNext(); ) {
       Document index = iterator.next();
       String name = (String) index.get("name");
       if (indexName.equals(name)) {

--- a/src/test/java/com/github/mongobee/dao/LockDaoTest.java
+++ b/src/test/java/com/github/mongobee/dao/LockDaoTest.java
@@ -17,13 +17,14 @@ public class LockDaoTest {
 
   private static final String TEST_SERVER = "testServer";
   private static final String DB_NAME = "mongobeetest";
+  private static final String LOCK_COLLECTION_NAME = "mongobeelock";
 
   @Test
   public void shouldGetLockWhenNotPreviouslyHeld() throws Exception {
 
     // given
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
-    LockDao dao = new LockDao();
+    LockDao dao = new LockDao(LOCK_COLLECTION_NAME);
     dao.intitializeLock(db);
 
     // when
@@ -39,7 +40,7 @@ public class LockDaoTest {
 
     // given
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
-    LockDao dao = new LockDao();
+    LockDao dao = new LockDao(LOCK_COLLECTION_NAME);
     dao.intitializeLock(db);
 
     // when
@@ -55,7 +56,7 @@ public class LockDaoTest {
 
     // given
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
-    LockDao dao = new LockDao();
+    LockDao dao = new LockDao(LOCK_COLLECTION_NAME);
     dao.intitializeLock(db);
 
     // when
@@ -71,7 +72,9 @@ public class LockDaoTest {
   public void releaseLockShouldBeIdempotent() {
     // given
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
-    LockDao dao = new LockDao();
+    LockDao dao = new LockDao(LOCK_COLLECTION_NAME);
+    
+    
     dao.intitializeLock(db);
 
     // when
@@ -87,7 +90,7 @@ public class LockDaoTest {
   public void whenLockNotHeldCheckReturnsFalse() {
 
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
-    LockDao dao = new LockDao();
+    LockDao dao = new LockDao(LOCK_COLLECTION_NAME);
     dao.intitializeLock(db);
 
     assertFalse(dao.isLockHeld(db));
@@ -98,7 +101,7 @@ public class LockDaoTest {
   public void whenLockHeldCheckReturnsTrue() {
 
     MongoDatabase db = new Fongo(TEST_SERVER).getDatabase(DB_NAME);
-    LockDao dao = new LockDao();
+    LockDao dao = new LockDao(LOCK_COLLECTION_NAME);
     dao.intitializeLock(db);
 
     dao.acquireLock(db);


### PR DESCRIPTION
Allow us to override the default collection names "dbchangelog" and "mongobeelock" used by MongoBee.